### PR TITLE
Add JSDoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![license](https://img.shields.io/badge/license-MIT-success)
 ![code size](https://img.shields.io/github/languages/code-size/neocarto/bertin)
 
-*geotoolbox* is a javascript tool for geographers. It allows one to manage geojson properties (attribute data) and provides several useful GIS operations for thematic cartography.
+*geotoolbox* is a javascript tool for geographers. It allows one to manage GeoJSON properties (attribute data) and provides several useful GIS operations for thematic cartography.
 
 ## 1. <ins>Installation</ins>
 
@@ -54,7 +54,7 @@ _Here we are talking about some basic functions which are useful for handling at
 
 ```js
 geo.add({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     field: "gdppc", // new colname (string) 
     expression: "gdp/pop*1000" // a string containing an expression
 })
@@ -64,7 +64,7 @@ geo.add({
 
 ```js
 geo.head({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     field: "gdp", // a colname (string)
     nb: 5 // default:10. Number of features to get. Here, the 5 richest countries.
 })
@@ -74,7 +74,7 @@ geo.head({
 
 ```js
 geo.keep({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     field: ["ISO3", "pop2020"] // colname(s) (string or array of strings) 
 })
 ```
@@ -83,16 +83,16 @@ geo.keep({
 
 ```js
 geo.remove({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     field: ["tmp", "FID"] // colname(s) (string or array of strings) 
 })
 ```
 
-**select** allows filtering a geojson object by its attribute table. This function returns a new object and does not modify the initial object.
+**select** allows filtering a GeoJSON FeatureCollection by its attribute table. This function returns a new object and does not modify the initial object.
 
 ```js
 geo.select({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     expression: "pop2022 >= 100000" // an expression (string) 
 })
 ```
@@ -101,24 +101,24 @@ geo.select({
 
 ```js
 geo.subset({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     field: "ISO3", // colname (string)
     selection: ["USA", "CAN", "MEX"], // values to be kept. Here, North American countries
     inverse: false // default: false. If true, all countries except USA, CAN and MEX are kept 
 })
 ```
 
-**table** allows getting a geojson attribute table.
+**table** allows getting a GeoJSON FeatureCollection attribute table.
 
 ```js
-geo.table(world // a geojson object
+geo.table(world // a GeoJSON object
 ```
 
 **tail** allows getting the n bottom values from a given field. This function returns a new object and does not modify the initial object.
 
 ```js
 geo.tail({
-    x: world, // a geojson object
+    x: world, // a GeoJSON object
     field: "gdp", // a colname (string)
     nb: 5 // default:10. Number of features to get. Here, the 5 least wealthy countries
 })
@@ -132,40 +132,40 @@ _Here we are talking about some basic functions which are useful for thematic ma
 ![aggregate](img/aggregate.svg)
 
 ```js
-geo.aggregate(world) // a geojson object
+geo.aggregate(world) // a GeoJSON object
 ```
 
 With options, you can compute an aggregate by id.
 
 ```js
 continents = geo.aggregate(
-    world, // a geojson object
+    world, // a GeoJSON object
     { 
         id: "continent" // ids
     })
 ```
 
-**bbox** allows returning a [geographic bounding box](https://www.jasondavies.com/maps/bounds/) as geojson from a geojson or a n array defining a bounding box `[[left, bottom], [right, top]]`. This function is based on Jacob Rus [code](https://observablehq.com/@jrus/sphere-resample). [Example](https://observablehq.com/@neocartocnrs/bbox?collection=@neocartocnrs/geotoolbox)
+**bbox** allows returning a [geographic bounding box](https://www.jasondavies.com/maps/bounds/) as GeoJSON from a GeoJSON or an array defining a bounding box `[[left, bottom], [right, top]]`. This function is based on Jacob Rus [code](https://observablehq.com/@jrus/sphere-resample). [Example](https://observablehq.com/@neocartocnrs/bbox?collection=@neocartocnrs/geotoolbox)
 
 ![bbox](img/bbox.svg)
 
 ```js
-geo.bbox(world) // a geojson object
+geo.bbox(world) // a GeoJSON object
 ```
 
-**border** allows extracting boundaries from a geojson object (polygons). With options, you can get ids and calculate discontinuities. [Example](https://observablehq.com/@neocartocnrs/border?collection=@neocartocnrs/geotoolbox)
+**border** allows extracting boundaries from a GeoJSON object (polygons). With options, you can get ids and calculate discontinuities. [Example](https://observablehq.com/@neocartocnrs/border?collection=@neocartocnrs/geotoolbox)
 
 ![border](img/border.svg)
 
 ```js
-geo.border(world) // a geojson object
+geo.border(world) // a GeoJSON object
 ```
 
 With options:
 
 ```js
 geo.border(
-    world, // a geojson object
+    world, // a GeoJSON object
     { 
         id: "ISO3", // ids
         values: "pop", // values
@@ -182,7 +182,7 @@ geo.border(
 geo.buffer(geojson, { dist: 1000 }) // 1000 km 
 ```
 
-The ```distance``` value can also be contained in a geojson field (in the properties). In this case, you just have to indicate the name of this field.
+The ```distance``` value can also be contained in a GeoJSON field (in the properties). In this case, you just have to indicate the name of this field.
 
 ```js
 geo.buffer(geojson, { dist: "a field" }) // a field in properties
@@ -206,7 +206,7 @@ The ```step``` option allows defining the precision of the buffer (default:8)
 geo.buffer(geojson, { dist: 1000, step:1 }) 
 ```
 
-You can use ```wgs84=false``` if your geojson is not in wgs84. In this case, the distance will be given in the map coordinates. 
+You can use ```wgs84=false``` if your GeoJSON is not in wgs84. In this case, the distance will be given in the map coordinates. 
 
 ```js
 geo.buffer(geojson, { dist: 1000, wgs84:false }) 
@@ -239,14 +239,14 @@ geo.clip(geojson1, {clip:geojson2, buffer: 100})
 ![centroid](img/centroid.svg)
 
 ```js
-geo.centroid(world) // a geojson (polygons) object
+geo.centroid(world) // a GeoJSON (polygons) object
 ```
 
 By default, the centroid is placed in the largest polygon. But you can avoid it.
 
 ```js
 geo.centroid(
-    world, // a geojson object
+    world, // a GeoJSON object
     {
         largest: false // largest polygon. true/false (default: true)
     })
@@ -256,14 +256,14 @@ It may happen that the coordinates of your base map are not in latitudes and lon
 
 ```js
 geo.centroid(
-    world, // a geojson object
+    world, // a GeoJSON object
     {
         largest: false, // largest polygon. true/false (default: true)
         planar: true // if geometries are already projected
     })
 ```
 
-**coords2geo** allows building a geojson object from a table with lat,lng coordinates. [Example](https://observablehq.com/@neocartocnrs/coords2geo?collection=@neocartocnrs/geotoolbox)
+**coords2geo** allows building a GeoJSON object from a table with lat,lng coordinates. [Example](https://observablehq.com/@neocartocnrs/coords2geo?collection=@neocartocnrs/geotoolbox)
 
 ![coords2geo](img/coords2geo.svg)
 
@@ -271,7 +271,7 @@ geo.centroid(
 geo.coords2geo(
     data, // a json object
     {
-        lat: "lat" // the field containing latitude coordinates (you can use also `latitude`) 
+        lat: "lat", // the field containing latitude coordinates (you can use also `latitude`) 
         lng: "lon" // the field containing longitude coordinates (you can use also `longitude`) 
     })
 ```
@@ -302,12 +302,12 @@ geo.coords2geo(
     })
 ```
 
-**dissolve** allows disolving geometries (multipart to single parts). [Example](https://observablehq.com/@neocartocnrs/dissolve?collection=@neocartocnrs/geotoolbox)
+**dissolve** allows dissolving geometries (multipart to single parts). [Example](https://observablehq.com/@neocartocnrs/dissolve?collection=@neocartocnrs/geotoolbox)
 
 ![dissolve](img/dissolve.svg)
 
 ```js
-geo.dissolve(world) // a geojson object
+geo.dissolve(world) // a GeoJSON object
 ```
 
 **union** allows merging polygon geometries. [Example](https://observablehq.com/@neocartocnrs/union?collection=@neocartocnrs/geotoolbox)
@@ -315,14 +315,14 @@ geo.dissolve(world) // a geojson object
 ![union](img/union.svg)
 
 ```js
-geo.union(world) // a geojson object
+geo.union(world) // a GeoJSON object
 ```
 
-With options, you can compute an union by id.
+With options, you can compute a union by id.
 
 ```js
 continents = geo.union(
-    world, // a geojson object
+    world, // a GeoJSON object
     { 
         id: "continent" // ids
     })
@@ -334,7 +334,7 @@ continents = geo.union(
 
 ```js
 geo.simplify(
-    world, // a geojson object
+    world, // a GeoJSON object
     { 
         k, // factor of simplification (default: 0.5)
         merge: false // true to merge geometries(default: false)
@@ -349,7 +349,7 @@ geo.simplify(
 geo.tissot(20) // step (default; 10)
 ```
 
-**geolines** allows getting the natural geographic lines such as equator, tropics & polar circles. [Example](https://observablehq.com/@neocartocnrs/geolines?collection=@neocartocnrs/geotoolbox)
+**geolines** allows getting the natural geographic lines such as the equator, tropics & polar circles. [Example](https://observablehq.com/@neocartocnrs/geolines?collection=@neocartocnrs/geotoolbox)
 
 ![geolines](img/geolines.svg)
 
@@ -359,7 +359,7 @@ geo.geolines()
 
 #### 3.3 Utils
 
-**filter** allows to create and returns a new geojson containing all the elements of the original geojson that meet a condition determined by the callback function applied on properties (or geometries). the function returns a new geojson and does not modify the initial geojson. Find examples [here](https://observablehq.com/@neocartocnrs/filter-geojson?collection=@neocartocnrs/geotoolbox).
+**filter** allows to create and returns a new GeoJSON containing all the elements of the original GeoJSON that meet a condition determined by the callback function applied on properties (or geometries). the function returns a new GeoJSON and does not modify the initial GeoJSON. Find examples [here](https://observablehq.com/@neocartocnrs/filter-geojson?collection=@neocartocnrs/geotoolbox).
 
 ![filter](img/filter.svg)
 
@@ -373,7 +373,7 @@ You can also do the same thing on geometries by specifying a third argument as "
 newworld = geo.filter(world, (d) => d3.geoArea(d) > area, "geometry")
 ```
 
-**map** allows to create a new geojson with the results of a function call provided on each element of geojson properties (or geometries). the function returns a new geojson and does not modify the initial geojson. Find examples [here](https://observablehq.com/@neocartocnrs/map-geojson?collection=@neocartocnrs/geotoolbox).
+**map** allows to create a new GeoJSON with the results of a function call provided on each element of GeoJSON properties (or geometries). the function returns a new GeoJSON and does not modify the initial GeoJSON. Find examples [here](https://observablehq.com/@neocartocnrs/map-geojson?collection=@neocartocnrs/geotoolbox).
 
 ![map](img/map.svg)
 
@@ -395,7 +395,7 @@ dot = geo.map(
 )
 ```
 
-**featurecollection** allows converting an array of features or an array of geometries to a well formated geosjon. [Example](https://observablehq.com/@neocartocnrs/featurecollection?collection=@neocartocnrs/geotoolbox)
+**featurecollection** allows converting an array of features or an array of geometries to a well formatted GeoJSON. [Example](https://observablehq.com/@neocartocnrs/featurecollection?collection=@neocartocnrs/geotoolbox)
 
 ![featurecollection](img/featurecollection.svg)
 
@@ -403,7 +403,7 @@ dot = geo.map(
 geo.featurecollection(features) 
 ```
 
-**type** allows get the geometry type of a geojson ("point", "line", "polygon")
+**type** allows get the geometry type of a GeoJSON ("point", "line", "polygon")
 
 ```js
 geo.type(geojson) 

--- a/src/gis/aggregate.js
+++ b/src/gis/aggregate.js
@@ -9,9 +9,12 @@ import { featurecollection } from "../utils/featurecollection.js";
  * Takes a FeatureCollection or a set of Features or Geometries and merge them
  * based on their topology.
  *
- * @param x - The targeted FeatureCollection / Features / Geometries
+ * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
  * @param {object} [options={}] - Optional parameters
- * @returns {{features: [{geometry: {coordinates: *, type: string}, type: string, properties: {}}], type: string}} - The new GeoJSON FeatureCollection
+ * @param {string} [options.id] - The id of the features to aggregate
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}} - The new GeoJSON FeatureCollection
+ *
+ * @see the <code>union</code> function
  *
  * Example: {@link https://observablehq.com/@neocartocnrs/aggregate?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */

--- a/src/gis/aggregate.js
+++ b/src/gis/aggregate.js
@@ -9,6 +9,8 @@ import { featurecollection } from "../utils/featurecollection.js";
  * Takes a FeatureCollection or a set of Features or Geometries and merge them
  * based on their topology.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/aggregate?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
  * @param {object} [options={}] - Optional parameters
  * @param {string} [options.id] - The id of the features to aggregate
@@ -16,7 +18,6 @@ import { featurecollection } from "../utils/featurecollection.js";
  *
  * @see the <code>union</code> function
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/aggregate?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function aggregate(x, options = {}) {
   x = featurecollection(x);

--- a/src/gis/aggregate.js
+++ b/src/gis/aggregate.js
@@ -5,6 +5,16 @@ import { merge } from "topojson-client";
 const topojson = Object.assign({}, { topology, merge });
 import { featurecollection } from "../utils/featurecollection.js";
 
+/**
+ * Takes a FeatureCollection or a set of Features or Geometries and merge them
+ * based on their topology.
+ *
+ * @param x - The targeted FeatureCollection / Features / Geometries
+ * @param {object} [options={}] - Optional parameters
+ * @returns {{features: [{geometry: {coordinates: *, type: string}, type: string, properties: {}}], type: string}} - The new GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/aggregate?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function aggregate(x, options = {}) {
   x = featurecollection(x);
   if (options.id != null && options.id != undefined) {

--- a/src/gis/bbox.js
+++ b/src/gis/bbox.js
@@ -6,6 +6,15 @@ import { geoEquirectangularRaw, geoBounds } from "d3-geo";
 const d3 = Object.assign({}, { geoEquirectangularRaw, geoBounds });
 import { featurecollection } from "../utils/featurecollection.js";
 
+/**
+ * Compute a geographic bounding box for a given FeatureCollection / array of Features / array of Geometries.
+ * The bounding box is returned wrapped in a FeatureCollection containing a single Polygon Feature.
+ *
+ * @param {object} _ - The targeted FeatureCollection / Features / Geometries
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}} - A FeatureCollection containing a single Polygon Feature, representing the bounding box
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/bbox?collection=@neocartocnrs/geotoolbox Observable notebook}
+ */
 export function bbox(_) {
   let bounds;
   if (!Array.isArray(_)) {

--- a/src/gis/bbox.js
+++ b/src/gis/bbox.js
@@ -10,10 +10,11 @@ import { featurecollection } from "../utils/featurecollection.js";
  * Compute a geographic bounding box for a given FeatureCollection / array of Features / array of Geometries.
  * The bounding box is returned wrapped in a FeatureCollection containing a single Polygon Feature.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/bbox?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} _ - The targeted FeatureCollection / Features / Geometries
  * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}} - A FeatureCollection containing a single Polygon Feature, representing the bounding box
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/bbox?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function bbox(_) {
   let bounds;

--- a/src/gis/border.js
+++ b/src/gis/border.js
@@ -10,6 +10,8 @@ const d3 = Object.assign({}, d3array);
  * (of polygons).
  * Options enable to get ids and calculate discontinuities.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/border?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object|array} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
  * @param {object} options - Optional parameters
  * @param {boolean} [options.id] - Get ids of boundaries
@@ -18,7 +20,6 @@ const d3 = Object.assign({}, d3array);
  * @param {boolean} [options.share] - Todo
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/border?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function border(geojson, options = {}) {
   let geo = featurecollection(geojson);

--- a/src/gis/border.js
+++ b/src/gis/border.js
@@ -10,7 +10,7 @@ const d3 = Object.assign({}, d3array);
  * (of polygons).
  * Options enable to get ids and calculate discontinuities.
  *
- * @param {object} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @param {object|array} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
  * @param {object} options - Optional parameters
  * @param {boolean} [options.id] - Get ids of boundaries
  * @param {boolean} [options.values] - Todo

--- a/src/gis/border.js
+++ b/src/gis/border.js
@@ -5,6 +5,21 @@ import { featurecollection } from "../utils/featurecollection.js";
 import * as d3array from "d3-array";
 const d3 = Object.assign({}, d3array);
 
+/**
+ * Extract boundaries from a GeoJSON FeatureCollection / an array of Features / an array of Geometries
+ * (of polygons).
+ * Options enable to get ids and calculate discontinuities.
+ *
+ * @param {object} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @param {object} options - Optional parameters
+ * @param {boolean} [options.id] - Get ids of boundaries
+ * @param {boolean} [options.values] - Todo
+ * @param {boolean} [options.type] - Todo
+ * @param {boolean} [options.share] - Todo
+ * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/border?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function border(geojson, options = {}) {
   let geo = featurecollection(geojson);
 

--- a/src/gis/buffer.js
+++ b/src/gis/buffer.js
@@ -8,6 +8,18 @@ const jsts = {
 };
 import { union } from "./union.js";
 import { clip } from "./clip.js";
+
+/**
+ * Build a buffer around a FeatureCollection or a set of Features or Geometries.
+ * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
+ * @param {object} options - Optional parameters
+ * @param {number|string} options.dist - The distance of the buffer in km or the name of the field containing the distance values
+ * @param {boolean} [options.clip] - Todo
+ * @param {boolean} [options.merge] - Todo
+ * @param {boolean} [options.step] - Todo
+ * @param {boolean} [options.wgs84] - Todo
+ * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
+ */
 import { km2deg } from "../utils/km2deg.js";
 import { featurecollection } from "../utils/featurecollection.js";
 

--- a/src/gis/buffer.js
+++ b/src/gis/buffer.js
@@ -12,6 +12,8 @@ import { clip } from "./clip.js";
 /**
  * Build a buffer around a FeatureCollection or a set of Features or Geometries.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/buffer?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
  * @param {object} options - Optional parameters
  * @param {number|string} options.dist - The distance of the buffer in km or the name of the field containing the distance values
@@ -21,7 +23,6 @@ import { clip } from "./clip.js";
  * @param {boolean} [options.wgs84=true] - Whether the input data is in WGS84 or not
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/buffer?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 import { km2deg } from "../utils/km2deg.js";
 import { featurecollection } from "../utils/featurecollection.js";

--- a/src/gis/buffer.js
+++ b/src/gis/buffer.js
@@ -15,10 +15,10 @@ import { clip } from "./clip.js";
  * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
  * @param {object} options - Optional parameters
  * @param {number|string} options.dist - The distance of the buffer in km or the name of the field containing the distance values
- * @param {boolean} [options.clip] - Todo
- * @param {boolean} [options.merge] - Todo
+ * @param {boolean} [options.clip] - Prevent the buffer to have coordinates that exceed [-90, 90] in latitude and [-180, 180]
+ * @param {boolean} [options.merge=false] - Merge all the output buffers into a single Geometry
  * @param {boolean} [options.step] - Todo
- * @param {boolean} [options.wgs84] - Todo
+ * @param {boolean} [options.wgs84=true] - Whether the input data is in WGS84 or not
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
  *
  * Example: {@link https://observablehq.com/@neocartocnrs/buffer?collection=@neocartocnrs/geotoolbox Observable Notebook}

--- a/src/gis/buffer.js
+++ b/src/gis/buffer.js
@@ -11,6 +11,7 @@ import { clip } from "./clip.js";
 
 /**
  * Build a buffer around a FeatureCollection or a set of Features or Geometries.
+ *
  * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
  * @param {object} options - Optional parameters
  * @param {number|string} options.dist - The distance of the buffer in km or the name of the field containing the distance values
@@ -19,6 +20,8 @@ import { clip } from "./clip.js";
  * @param {boolean} [options.step] - Todo
  * @param {boolean} [options.wgs84] - Todo
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/buffer?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 import { km2deg } from "../utils/km2deg.js";
 import { featurecollection } from "../utils/featurecollection.js";

--- a/src/gis/centroid.js
+++ b/src/gis/centroid.js
@@ -13,13 +13,14 @@ const d3 = Object.assign({}, { geoArea, geoCentroid, geoIdentity, geoPath });
  * This can be changed by setting the <code>options.largest</code> parameter
  * to <code>false</code>.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/centroid?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object|array} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
  * @param {object} options - Optional parameters
  * @param {boolean} [options.largest=true] - Place the centroid in the largest polygon.
  * @param {boolean} [options.planar=false] - Use planar projection.
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/centroid?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function centroid(geojson, options = {}) {
   let largest = options.largest === false ? false : true;

--- a/src/gis/centroid.js
+++ b/src/gis/centroid.js
@@ -4,6 +4,23 @@ import { geoArea, geoCentroid, geoIdentity, geoPath } from "d3-geo";
 import { featurecollection } from "../utils/featurecollection.js";
 
 const d3 = Object.assign({}, { geoArea, geoCentroid, geoIdentity, geoPath });
+
+/**
+ * Calculate the centroid of all the geometries given in a
+ * GeoJSON FeatureCollection / array of Features / array of Geometries.
+ *
+ * By default, the centroid is placed in the largest polygon of each geometry.
+ * This can be changed by setting the <code>options.largest</code> parameter
+ * to <code>false</code>.
+ *
+ * @param {object|array} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @param {object} options - Optional parameters
+ * @param {boolean} [options.largest=true] - Place the centroid in the largest polygon.
+ * @param {boolean} [options.planar=false] - Use planar projection.
+ * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/centroid?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function centroid(geojson, options = {}) {
   let largest = options.largest === false ? false : true;
   let planar = options.planar === true ? true : false;

--- a/src/gis/clip.js
+++ b/src/gis/clip.js
@@ -16,12 +16,13 @@ import { featurecollection } from "../utils/featurecollection.js";
  * Clip a FeatureCollection (or a set of Features or Geometries) with another FeatureCollection
  * (or with another set of Features or Geometries).
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/clip?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object|array} x - The GeoJSON FeatureCollection / array of Features / array of Geometries
  * @param {object} options - Optional parameters
  * @param {object} options.clip - The clipping GeoJSON FeatureCollection / array of Features / array of Geometries
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/clip?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function clip(x, options = {}) {
   let reader = new jsts.GeoJSONReader();

--- a/src/gis/clip.js
+++ b/src/gis/clip.js
@@ -12,6 +12,17 @@ const jsts = {
 
 import { featurecollection } from "../utils/featurecollection.js";
 
+/**
+ * Clip a FeatureCollection (or a set of Features or Geometries) with another FeatureCollection
+ * (or with another set of Features or Geometries).
+ *
+ * @param {object|array} x - The GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @param {object} options - Optional parameters
+ * @param {object} options.clip - The clipping GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/clip?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function clip(x, options = {}) {
   let reader = new jsts.GeoJSONReader();
   let writer = new jsts.GeoJSONWriter();

--- a/src/gis/dissolve.js
+++ b/src/gis/dissolve.js
@@ -1,8 +1,6 @@
 import { geoArea } from "d3-geo";
 import { featurecollection } from "../utils/featurecollection.js";
 
-// Multi part to single part geometries
-
 /**
  * Dissolve multipart geometries to single part geometries.
  *

--- a/src/gis/dissolve.js
+++ b/src/gis/dissolve.js
@@ -4,10 +4,11 @@ import { featurecollection } from "../utils/featurecollection.js";
 /**
  * Dissolve multipart geometries to single part geometries.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/dissolve?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param geojson - The target GeoJSON FeatureCollection / array of Features / array of Geometries
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/dissolve?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function dissolve(geojson) {
   geojson = featurecollection(geojson);

--- a/src/gis/dissolve.js
+++ b/src/gis/dissolve.js
@@ -3,6 +3,14 @@ import { featurecollection } from "../utils/featurecollection.js";
 
 // Multi part to single part geometries
 
+/**
+ * Dissolve multipart geometries to single part geometries.
+ *
+ * @param geojson - The target GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}} - The resulting GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/dissolve?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function dissolve(geojson) {
   geojson = featurecollection(geojson);
   let result = [];

--- a/src/gis/geolines.js
+++ b/src/gis/geolines.js
@@ -1,3 +1,11 @@
+/**
+ * Returns a GeoJSON FeatureCollection of natural geographic lines such as
+ * the equator, tropics & polar circles.
+ *
+ * @returns {{features: *[], type: string}}
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/geolines?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function geolines() {
   let features = [];
   let arr = [

--- a/src/gis/geolines.js
+++ b/src/gis/geolines.js
@@ -2,9 +2,10 @@
  * Returns a GeoJSON FeatureCollection of natural geographic lines such as
  * the equator, tropics & polar circles.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/geolines?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @returns {{features: *[], type: string}}
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/geolines?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function geolines() {
   let features = [];

--- a/src/gis/simplify.js
+++ b/src/gis/simplify.js
@@ -13,13 +13,13 @@ import { union } from "./union.js";
  * Simplify geometries of a GeoJSON FeatureCollection / Array of Features / Array of Geometries
  * using <code>topojson-simplify</code> library.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/simplify?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {array|object} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
  * @param {object} options - Optional parameters
  * @param {number} [options.k=0.5] - The quantile of the simplification
- * @param {boolean} [option.merge=false] - Merge geometries after simplification
+ * @param {boolean} [options.merge=false] - Merge geometries after simplification
  * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}}
- *
- * Example: {@link https://observablehq.com/@neocartocnrs/simplify?collection=@neocartocnrs/geotoolbox Observable Notebook}
  *
  * @example
  * geo.simplify(

--- a/src/gis/simplify.js
+++ b/src/gis/simplify.js
@@ -9,6 +9,26 @@ const topojson = Object.assign(
 );
 import { union } from "./union.js";
 
+/**
+ * Simplify geometries of a GeoJSON FeatureCollection / Array of Features / Array of Geometries
+ * using <code>topojson-simplify</code> library.
+ *
+ * @param {array|object} geojson - The GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @param {object} options - Optional parameters
+ * @param {number} [options.k=0.5] - The quantile of the simplification
+ * @param {boolean} [option.merge=false] - Merge geometries after simplification
+ * @returns {{features: {geometry: {}, type: string, properties: {}}[], type: string}}
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/simplify?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ *
+ * @example
+ * geo.simplify(
+ *     world,
+ *     {
+ *         k, // factor of simplification (default: 0.5)
+ *         merge: false // true to merge geometries(default: false)
+ *     })
+ */
 export function simplify(geojson, options = {}) {
   let k = options.k ? options.k : 0.5;
   // union or not

--- a/src/gis/tissot.js
+++ b/src/gis/tissot.js
@@ -3,10 +3,11 @@ import { geoCircle } from "d3-geo";
 /**
  * Generate Tissot's indicatrix.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/tissot?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {number} step - The distance between each circle
  * @returns {{features: *[], type: string}} - The resulting GeoJSON FeatureCollection
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/tissot?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function tissot(step) {
   const circle = geoCircle()

--- a/src/gis/tissot.js
+++ b/src/gis/tissot.js
@@ -1,5 +1,13 @@
 import { geoCircle } from "d3-geo";
 
+/**
+ * Generate Tissot's indicatrix.
+ *
+ * @param {number} step - The distance between each circle
+ * @returns {{features: *[], type: string}} - The resulting GeoJSON FeatureCollection
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/tissot?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function tissot(step) {
   const circle = geoCircle()
     .center((d) => d)

--- a/src/gis/union.js
+++ b/src/gis/union.js
@@ -14,6 +14,18 @@ const jsts = {
   GeoJSONWriter,
 };
 
+/**
+ * Takes a FeatureCollection or a set of Features or Geometries containing Polygons and merge them.
+ *
+ * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
+ * @param {object} [options={}] - Optional parameters
+ * @param {string} [options.id] - The id of the features to aggregate
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}} - The new GeoJSON FeatureCollection
+ *
+ * @see the <code>aggregate</code> function
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/union?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ */
 export function union(x, options = {}) {
   x = featurecollection(x);
   let geomtype = type(x);

--- a/src/gis/union.js
+++ b/src/gis/union.js
@@ -17,6 +17,8 @@ const jsts = {
 /**
  * Takes a FeatureCollection or a set of Features or Geometries containing Polygons and merge them.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/union?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object|array} x - The targeted FeatureCollection / Features / Geometries
  * @param {object} [options={}] - Optional parameters
  * @param {string} [options.id] - The id of the features to aggregate
@@ -24,7 +26,6 @@ const jsts = {
  *
  * @see the <code>aggregate</code> function
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/union?collection=@neocartocnrs/geotoolbox Observable Notebook}
  */
 export function union(x, options = {}) {
   x = featurecollection(x);

--- a/src/iterator/filter.js
+++ b/src/iterator/filter.js
@@ -5,7 +5,7 @@
  *
  * The function returns a new GeoJSON FeatureCollection and does not modify the initial GeoJSON Object.
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/filter-geojson?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ * Example: {@link https://observablehq.com/@neocartocnrs/filter-geojson?collection=@neocartocnrs/geotoolbox Observable notebook}
  *
  * @see the <code>map</code> function
  *

--- a/src/iterator/filter.js
+++ b/src/iterator/filter.js
@@ -9,8 +9,6 @@
  *
  * @see the <code>map</code> function
  *
- * @function
- * @name filter
  * @param {object} geojson - The FeatureCollection to iterate over
  * @param {function} func - The callback function to apply on each element
  * @param {string} [key=properties] - The key to apply the callback function on

--- a/src/iterator/filter.js
+++ b/src/iterator/filter.js
@@ -1,3 +1,21 @@
+/**
+ * Create and returns a new GeoJSON FeatureCollection containing all
+ * the elements of the original GeoJSON FeatureCollection that meet a condition
+ * determined by the callback function applied on properties (or geometries).
+ *
+ * The function returns a new GeoJSON FeatureCollection and does not modify the initial GeoJSON Object.
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/filter-geojson?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ *
+ * @see the <code>map</code> function
+ *
+ * @function
+ * @name filter
+ * @param {object} geojson - The FeatureCollection to iterate over
+ * @param {function} func - The callback function to apply on each element
+ * @param {string} [key=properties] - The key to apply the callback function on
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}}
+ */
 export function filter(geojson, func = (d) => d, key = "properties") {
   let x = { ...geojson };
   let features = x.features;

--- a/src/iterator/filter.js
+++ b/src/iterator/filter.js
@@ -1,5 +1,5 @@
 /**
- * Create and returns a new GeoJSON FeatureCollection containing all
+ * Create and return a new GeoJSON FeatureCollection containing all
  * the elements of the original GeoJSON FeatureCollection that meet a condition
  * determined by the callback function applied on properties (or geometries).
  *
@@ -12,7 +12,7 @@
  * @param {object} geojson - The FeatureCollection to iterate over
  * @param {function} func - The callback function to apply on each element
  * @param {string} [key=properties] - The key to apply the callback function on
- * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}}
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}} - The new GeoJSON FeatureCollection
  */
 export function filter(geojson, func = (d) => d, key = "properties") {
   let x = { ...geojson };

--- a/src/iterator/map.js
+++ b/src/iterator/map.js
@@ -13,7 +13,7 @@
  * @param {object} geojson - The FeatureCollection to iterate over
  * @param {function} func - The callback function to apply on each element
  * @param {string} [key=properties] - The key to apply the callback function on
- * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}}
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}} - The new GeoJSON FeatureCollection
  */
 export function map(geojson, func = (d) => d, key = "properties") {
   let x = { ...geojson };

--- a/src/iterator/map.js
+++ b/src/iterator/map.js
@@ -1,3 +1,20 @@
+/**
+ * Create a new GeoJSON FeatureCollection with the results
+ * of a function call provided on each element
+ * of GeoJSON properties (or geometries).
+ *
+ * The function returns a new GeoJSON FeatureCollection
+ * and does not modify the initial GeoJSON Object.
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/map-geojson?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ *
+ * @see the <code>filter</code> function
+ *
+ * @param {object} geojson - The FeatureCollection to iterate over
+ * @param {function} func - The callback function to apply on each element
+ * @param {string} [key=properties] - The key to apply the callback function on
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}}
+ */
 export function map(geojson, func = (d) => d, key = "properties") {
   let x = { ...geojson };
   let features = x.features;

--- a/src/iterator/map.js
+++ b/src/iterator/map.js
@@ -6,7 +6,7 @@
  * The function returns a new GeoJSON FeatureCollection
  * and does not modify the initial GeoJSON Object.
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/map-geojson?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ * Example: {@link https://observablehq.com/@neocartocnrs/map-geojson?collection=@neocartocnrs/geotoolbox Observable notebook}
  *
  * @see the <code>filter</code> function
  *

--- a/src/properties/add.js
+++ b/src/properties/add.js
@@ -1,5 +1,24 @@
 // Add
 import { str2fun } from "./str2fun.js";
+
+/**
+ * Add a new field in the attribute table of the GeoJSON FeatureCollection.
+ * This function returns a new object and does not modify the initial object.
+ *
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string} obj.field - The name of the new field
+ * @param {string} obj.expression - The expression, as a string, to compute the new field
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @example
+ * geo.add({
+ *     x: world,
+ *     field: "gdppc",
+ *     expression: "gdp/pop*1000",
+ * })
+ */
 export function add({ x, field, expression }) {
   let data = [...x.features.map((d) => ({ ...d.properties }))];
 

--- a/src/properties/add.js
+++ b/src/properties/add.js
@@ -18,6 +18,8 @@ import { str2fun } from "./str2fun.js";
  *     field: "gdppc",
  *     expression: "gdp/pop*1000",
  * })
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function add({ x, field, expression }) {
   let data = [...x.features.map((d) => ({ ...d.properties }))];

--- a/src/properties/add.js
+++ b/src/properties/add.js
@@ -5,6 +5,7 @@ import { str2fun } from "./str2fun.js";
  * Add a new field in the attribute table of the GeoJSON FeatureCollection.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
@@ -19,7 +20,7 @@ import { str2fun } from "./str2fun.js";
  *     expression: "gdp/pop*1000",
  * })
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  */
 export function add({ x, field, expression }) {
   let data = [...x.features.map((d) => ({ ...d.properties }))];

--- a/src/properties/head.js
+++ b/src/properties/head.js
@@ -16,6 +16,8 @@
  *     field: "gdp",
  *     nb: 5,
  * })
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function head({ x, field, nb = 10 }) {
   let features = [...x.features];

--- a/src/properties/head.js
+++ b/src/properties/head.js
@@ -1,4 +1,22 @@
-// head
+/**
+ * Get the first n Features of a GeoJSON FeatureCollection.
+ * This function returns a new object and does not modify the initial object.
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string} obj.field - The name of the field to be returned
+ * @param {number} obj.nb - The number of elements to be returned
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @see the <code>tail</code> function to get the last n Features
+ *
+ * @example
+ * geo.head({
+ *     x: world,
+ *     field: "gdp",
+ *     nb: 5,
+ * })
+ */
 export function head({ x, field, nb = 10 }) {
   let features = [...x.features];
   features = features

--- a/src/properties/head.js
+++ b/src/properties/head.js
@@ -2,6 +2,8 @@
  * Get the first n Features of a GeoJSON FeatureCollection.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
  * @param {string} obj.field - The name of the field to be returned
@@ -17,7 +19,6 @@
  *     nb: 5,
  * })
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function head({ x, field, nb = 10 }) {
   let features = [...x.features];

--- a/src/properties/keep.js
+++ b/src/properties/keep.js
@@ -1,7 +1,23 @@
 import { remove } from "./remove.js";
 
-// Keep only theses fields
-export function keep({ x, field }) {
+/**
+ * Keep only the specified fields in the attribute table of the GeoJSON FeatureCollection.
+ * This function returns a new object and does not modify the initial object.
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string[]} obj.fields - The name of the fields to be kept
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @see the <code>remove</code> function to remove the specified fields
+ *
+ * @example
+ * geo.keep({
+ *     x: world,
+ *     field: ["ISO3", "pop2020"],
+ * })
+ */
+export function keep({ x, fields }) {
   // Get all keys
   let keys = [];
   x.features
@@ -12,6 +28,6 @@ export function keep({ x, field }) {
   keys = Array.from(new Set(keys.flat()));
 
   // Fields to be removed
-  let diff = keys.filter((k) => !field.includes(k));
+  let diff = keys.filter((k) => !fields.includes(k));
   return remove({ x, field: diff });
 }

--- a/src/properties/keep.js
+++ b/src/properties/keep.js
@@ -4,6 +4,8 @@ import { remove } from "./remove.js";
  * Keep only the specified fields in the attribute table of the GeoJSON FeatureCollection.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
  * @param {string[]} obj.fields - The name of the fields to be kept
@@ -17,7 +19,6 @@ import { remove } from "./remove.js";
  *     field: ["ISO3", "pop2020"],
  * })
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function keep({ x, fields }) {
   // Get all keys

--- a/src/properties/keep.js
+++ b/src/properties/keep.js
@@ -16,6 +16,8 @@ import { remove } from "./remove.js";
  *     x: world,
  *     field: ["ISO3", "pop2020"],
  * })
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function keep({ x, fields }) {
   // Get all keys

--- a/src/properties/remove.js
+++ b/src/properties/remove.js
@@ -1,4 +1,20 @@
-// Remove fields
+/**
+ * Remove one or several columns in the attribute table.
+ * This function returns a new object and does not modify the initial object.
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string|string[]} obj.field - The name of the field(s) to be removed
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @see the <code>keep</code> function to keep only the specified fields
+ *
+ * @example
+ * geo.remove({
+ *     x: world,
+ *     field: ["tmp", "FID"],
+ * })
+ */
 export function remove({ x, field }) {
   let data = [...x.features.map((d) => ({ ...d.properties }))];
   data.forEach((d) => {

--- a/src/properties/remove.js
+++ b/src/properties/remove.js
@@ -13,7 +13,9 @@
  * geo.remove({
  *     x: world,
  *     field: ["tmp", "FID"],
- * })
+ * }):
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function remove({ x, field }) {
   let data = [...x.features.map((d) => ({ ...d.properties }))];

--- a/src/properties/remove.js
+++ b/src/properties/remove.js
@@ -2,6 +2,8 @@
  * Remove one or several columns in the attribute table.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
  * @param {string|string[]} obj.field - The name of the field(s) to be removed
@@ -15,7 +17,6 @@
  *     field: ["tmp", "FID"],
  * }):
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function remove({ x, field }) {
   let data = [...x.features.map((d) => ({ ...d.properties }))];

--- a/src/properties/select.js
+++ b/src/properties/select.js
@@ -14,6 +14,8 @@ import { str2fun } from "./str2fun.js";
  *     x: world,
  *     expression: "pop2022 >= 100000",
  * })
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function select({ x, expression }) {
   let features = [...x.features];

--- a/src/properties/select.js
+++ b/src/properties/select.js
@@ -1,5 +1,20 @@
-// Filter
 import { str2fun } from "./str2fun.js";
+
+/**
+ * Filter a GeoJSON FeatureCollection by its attribute table.
+ * This function returns a new object and does not modify the initial object.
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string} obj.expression - The name of the field to be filtered
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @example
+ * geo.select({
+ *     x: world,
+ *     expression: "pop2022 >= 100000",
+ * })
+ */
 export function select({ x, expression }) {
   let features = [...x.features];
 

--- a/src/properties/select.js
+++ b/src/properties/select.js
@@ -4,6 +4,8 @@ import { str2fun } from "./str2fun.js";
  * Filter a GeoJSON FeatureCollection by its attribute table.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
  * @param {string} obj.expression - The name of the field to be filtered
@@ -15,7 +17,6 @@ import { str2fun } from "./str2fun.js";
  *     expression: "pop2022 >= 100000",
  * })
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function select({ x, expression }) {
   let features = [...x.features];

--- a/src/properties/subset.js
+++ b/src/properties/subset.js
@@ -1,4 +1,22 @@
-// Subset
+/**
+ * Create a subset from an array of values.
+ * This function returns a new object and does not modify the initial object.
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string} obj.field - The name of the field on which the subset is based
+ * @param {string[]} obj.selection - The values to be selected
+ * @param {boolean} [obj.inverse=false] - If true, the selection is inverted
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @example
+ * geo.subset({
+ *     x: world,
+ *     field: "ISO3",
+ *     selection: ["USA", "CAN", "MEX"],
+ *     inverse: false,
+ * })
+ */
 export function subset({ x, field, selection, inverse = false }) {
   let features = [...x.features];
   selection = !Array.isArray(selection) ? [selection] : selection;

--- a/src/properties/subset.js
+++ b/src/properties/subset.js
@@ -2,6 +2,8 @@
  * Create a subset from an array of values.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
  * @param {string} obj.field - The name of the field on which the subset is based
@@ -17,7 +19,6 @@
  *     inverse: false,
  * })
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function subset({ x, field, selection, inverse = false }) {
   let features = [...x.features];

--- a/src/properties/subset.js
+++ b/src/properties/subset.js
@@ -16,6 +16,8 @@
  *     selection: ["USA", "CAN", "MEX"],
  *     inverse: false,
  * })
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function subset({ x, field, selection, inverse = false }) {
   let features = [...x.features];

--- a/src/properties/table.js
+++ b/src/properties/table.js
@@ -3,10 +3,11 @@
  * (i.e. the properties of each Feature).
  * This function returns a deep copy of the original properties.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} geojson - The targeted GeoJSON FeatureCollection
  * @returns {object[]} - The attribute table
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function table(geojson) {
   return JSON.parse(JSON.stringify(geojson.features.map((d) => d.properties)));

--- a/src/properties/table.js
+++ b/src/properties/table.js
@@ -5,6 +5,8 @@
  *
  * @param {object} geojson - The targeted GeoJSON FeatureCollection
  * @returns {object[]} - The attribute table
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function table(geojson) {
   return JSON.parse(JSON.stringify(geojson.features.map((d) => d.properties)));

--- a/src/properties/table.js
+++ b/src/properties/table.js
@@ -1,5 +1,11 @@
-// Attribute table
-
+/**
+ * Return the attribute table of the GeoJSON FeatureCollection
+ * (i.e. the properties of each Feature).
+ * This function returns a deep copy of the original properties.
+ *
+ * @param {object} geojson - The targeted GeoJSON FeatureCollection
+ * @returns {object[]} - The attribute table
+ */
 export function table(geojson) {
   return JSON.parse(JSON.stringify(geojson.features.map((d) => d.properties)));
 }

--- a/src/properties/tail.js
+++ b/src/properties/tail.js
@@ -2,6 +2,8 @@
  * Get the last n Features of a GeoJSON FeatureCollection.
  * This function returns a new object and does not modify the initial object.
  *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
+ *
  * @param {object} obj - An object with the following properties
  * @param {object} obj.x - The targeted GeoJSON FeatureCollection
  * @param {string} obj.field - The name of the field to be returned
@@ -17,7 +19,6 @@
  *     nb: 5,
  * })
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function tail({ x, field, nb = 10 }) {
   let features = [...x.features];

--- a/src/properties/tail.js
+++ b/src/properties/tail.js
@@ -1,4 +1,22 @@
-// tail
+/**
+ * Get the last n Features of a GeoJSON FeatureCollection.
+ * This function returns a new object and does not modify the initial object.
+ *
+ * @param {object} obj - An object with the following properties
+ * @param {object} obj.x - The targeted GeoJSON FeatureCollection
+ * @param {string} obj.field - The name of the field to be returned
+ * @param {number} obj.nb - The number of elements to be returned
+ * @returns {object} - The new GeoJSON FeatureCollection
+ *
+ * @see the <code>head</code> function to get the first n Features
+ *
+ * @example
+ * geo.tail({
+ *     x: world,
+ *     field: "gdp",
+ *     nb: 5,
+ * })
+ */
 export function tail({ x, field, nb = 10 }) {
   let features = [...x.features];
   features = features

--- a/src/properties/tail.js
+++ b/src/properties/tail.js
@@ -16,6 +16,8 @@
  *     field: "gdp",
  *     nb: 5,
  * })
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/handle-properties?collection=@neocartocnrs/geotoolbox Observable notebook}
  */
 export function tail({ x, field, nb = 10 }) {
   let features = [...x.features];

--- a/src/utils/featurecollection.js
+++ b/src/utils/featurecollection.js
@@ -8,7 +8,7 @@
  *
  * If the GeoJSON object is already a FeatureCollection, it is returned as-is.
  *
- * Example: {@link https://observablehq.com/@neocartocnrs/featurecollection?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ * Example: {@link https://observablehq.com/@neocartocnrs/featurecollection?collection=@neocartocnrs/geotoolbox Observable notebook}
  *
  * @param {object} x - The GeoJSON object(s) to wrap in a FeatureCollection
  * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}}

--- a/src/utils/featurecollection.js
+++ b/src/utils/featurecollection.js
@@ -1,3 +1,18 @@
+/**
+ * Wrap a GeoJSON object in a FeatureCollection.
+ * It accepts:
+ * - a single Feature
+ * - a single Geometry
+ * - an array of Features
+ * - an array of Geometries
+ *
+ * If the GeoJSON object is already a FeatureCollection, it is returned as-is.
+ *
+ * Example: {@link https://observablehq.com/@neocartocnrs/featurecollection?collection=@neocartocnrs/geotoolbox Observable Notebook}
+ *
+ * @param {object} x - The GeoJSON object(s) to wrap in a FeatureCollection
+ * @returns {{features: [{geometry:{}, type: string, properties: {}}], type: string}}
+ */
 export function featurecollection(x) {
   x = JSON.parse(JSON.stringify(x));
   if (x.type == "FeatureCollection" && !Array.isArray(x)) {

--- a/src/utils/type.js
+++ b/src/utils/type.js
@@ -1,5 +1,11 @@
 import { featurecollection } from "./featurecollection.js";
 
+/**
+ * Return the geometry type contained in a GeoJSON FeatureCollection / an array of Features / an array of Geometries.
+ *
+ * @param {object|array} x - The GeoJSON FeatureCollection / array of Features / array of Geometries
+ * @returns {string} - The type of the geometries, between "point", "line", "poly" and "composite" (when different types of geometries are encountered)
+ */
 export function type(x) {
   let figuration = ["poly", "line", "point"];
   let types = featurecollection(x).features.map((d) => d.geometry.type);


### PR DESCRIPTION
This is a draft PR about adding documentation (in JSDoc format) to all the exported function of geotoolbox.

JSDoc benefits from a builtin support in various IDE such as VSCode and Jetbrains WebStorm, allowing the user to get a nice information box when using these functions (see screenshot below).

![example-jsdoc](https://user-images.githubusercontent.com/12172162/210538202-287efe38-267c-432a-ba27-f7562c482f35.png)

I will try to complete the other functions soon and maybe we can use github review tool if we need to discuss on the wording of some comments (but this will be mainly the documentation you already wrote in the README).
